### PR TITLE
Add support for Bitbucket pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,24 @@
+image: node:20
+
+pipelines:
+  tags:
+    '*':
+      - step:
+          name: Build
+          caches:
+            - node
+          script:
+            - npm ci --cache .npm --prefer-offline
+            - npm run test
+      - step:
+          name: Publish
+          caches:
+            - node
+          script:
+            - npm ci --cache .npm --prefer-offline
+            - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+            - npm publish
+
+definitions:
+  caches:
+    node: .npm/


### PR DESCRIPTION
Added support for running the CI/CD pipelines on bitbucket.

This pipeline runs on each pull-request and each time the main branch gets new changes.

Required vars: NPM_TOKEN